### PR TITLE
Add non-www domain to Kamal proxy configuration

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -19,7 +19,9 @@ servers:
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
   ssl: true
-  host: www.rubyonwheels.com
+  hosts:
+    - www.rubyonwheels.com
+    - rubyonwheels.com
 
 # Credentials for your image host.
 registry:


### PR DESCRIPTION
Allow both www.rubyonwheels.com and rubyonwheels.com to access the application.

This closes #5 